### PR TITLE
ci(readthedocs): install package

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -27,6 +27,7 @@ sphinx:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#    install:
-#    - requirements: docs/requirements.txt
+python:
+   install:
+   - method: pip
+     path: .


### PR DESCRIPTION
Auto-generating documentation from docstrings will require the `datasalad` package to be installed.