### PR TITLE
style(changelog): add Jinja template for changelog generation

### DIFF
--- a/.changelog.md.j2
+++ b/.changelog.md.j2
@@ -1,0 +1,36 @@
+{% for entry in tree %}
+
+# {{ entry.version }}{% if entry.date %} ({{ entry.date }}){% endif %}
+
+{% for change_key, changes in entry.changes.items() %}
+
+{% if change_key %}
+## {{ change_key }}
+{% endif %}
+{% set scopemap = {
+  'changelog': 'Changelog',
+  'contributing': 'Contributing guide',
+  'helpers': 'Helpers',
+  'sphinx': 'Rendered documentation',
+  'typeannotation': 'Type annotation',
+} %}
+
+{# track what changelog scope we already saw for this change_key #}
+{% set ns = namespace(saw_scopes=[]) %}
+{% for change in changes | sort(attribute=scope) %}
+{% set indent = '' %}
+{% if change.scope %}
+{% set indent = '  ' %}
+{# write out scope, if it is new #}
+{% if change.scope not in ns.saw_scopes %}
+{% set ns.saw_scopes = ns.saw_scopes + [change.scope] %}
+- {{ scopemap.get(change.scope, change.scope) }}:
+{% endif %}
+{% endif %}
+{%- if change.message %}
+{{ indent }}- {{ change.message }}
+{%- endif %}
+ [[{{ change.sha1 | truncate(8, true, '') }}]](https://github.com/datalad/datalad-next/commit/{{ change.sha1 | truncate(8, true, '') }})
+{% endfor %}
+{% endfor %}
+{% endfor %}


### PR DESCRIPTION
This template is based on the one used by `datalad-next`, but is modified to auto-compact items with the same scope identifier. Moreover, a custom mapping is introduced (in the template) that can be used to beautify observed scope identifiers.

Here is a demo output:

```
  ## Tests

  - CommandError:
    - document and verify amending `CommandError.msg` [[9c724273]](https://github.com/datalad/datalad-next/commit/9c724273)
    - test least-information `CommandError` [[2cb8c480]](https://github.com/datalad/datalad-next/commit/2cb8c480)
    - check equivalence of `str()` and `to_str()` [[468244af]](https://github.com/datalad/datalad-next/commit/468244af)
  - Helpers:
    - discontinue use of nose-age `assert_equal` [[ffb8ea4b]](https://github.com/datalad/datalad-next/commit/ffb8ea4b)
```