### PR TITLE
doc(tests): add a note on confusing re coverage estimation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ source = "vcs"
 default-args = ["datasalad"]
 extra-dependencies = [
   "pytest",
+  # if you come here, because coverage combination crashed for you
+  # run `hatch test --cover` and/or see
+  # https://github.com/pypa/hatch/issues/1565#issuecomment-2163773123
   "pytest-cov",
 ]
 


### PR DESCRIPTION
I (unintentionally) ran `hatch test -cov` not `hatch test --cover`, using pytest-cov directly, rather than going through the respective `hatch` functionality, leading to a crash.

Closes: https://github.com/datalad/datasalad/issues/24