### PR TITLE
fix(changelog): reimport changelog template from datalad-next

### DIFF
--- a/.changelog.md.j2
+++ b/.changelog.md.j2
@@ -15,22 +15,16 @@
   'typeannotation': 'Type annotation',
 } %}
 
-{# track what changelog scope we already saw for this change_key #}
-{% set ns = namespace(saw_scopes=[]) %}
-{% for change in changes | sort(attribute=scope) %}
-{% set indent = '' %}
-{% if change.scope %}
-{% set indent = '  ' %}
-{# write out scope, if it is new #}
-{% if change.scope not in ns.saw_scopes %}
-{% set ns.saw_scopes = ns.saw_scopes + [change.scope] %}
-- {{ scopemap.get(change.scope, change.scope) }}:
-{% endif %}
-{% endif %}
-{%- if change.message %}
-{{ indent }}- {{ change.message }}
-{%- endif %}
- [[{{ change.sha1 | truncate(8, true, '') }}]](https://github.com/datalad/datalad-next/commit/{{ change.sha1 | truncate(8, true, '') }})
+{# no-scope changes #}
+{% for change in changes | rejectattr("scope") %}
+- {{ change.message }} [[{{ change.sha1 | truncate(8, true, '') }}]](https://github.com/datalad/datalad-next/commit/{{ change.sha1 | truncate(8, true, '') }})
+{% endfor %}
+{# scoped changes #}
+{% for scope, scope_changes in changes | selectattr("scope") | groupby("scope") %}
+- {{ scopemap.get(scope, scope) }}:
+{% for change in scope_changes %}
+  - {{ change.message }} [[{{ change.sha1 | truncate(8, true, '') }}]](https://github.com/datalad/datalad-next/commit/{{ change.sha1 | truncate(8, true, '') }})
+{% endfor %}
 {% endfor %}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
It has a fix that prevent undesired swallowing of change scopes. The new setup does not rely on sorting the scopes anymore. Instead, it reports changes without a scop first, and the rest, grouped by scope, afterwards.