### PR TITLE
Fix test that is unreliable on Windows.

### DIFF
--- a/datasalad/iterable_subprocess/test_iterable_subprocess.py
+++ b/datasalad/iterable_subprocess/test_iterable_subprocess.py
@@ -415,10 +415,11 @@ def test_returncode_available_from_generator_with_exception():
             while True:
                 next(echo)
     # On a Linux system, all exceptions that are raised before the subprocess
-    # exited will lead to a -15 return code. If StopIteration is raised, the
+    # exited will lead to a -15 return code. On a Windows system, exceptions
+    # will lead to a 1 return code. If StopIteration is raised, the
     # subprocess will either have terminated which results in a 0-return code,
     # or the subprocess is still running and will therefore be terminated which
-    # results in a -15 return code. Any other exception than StopIteration,
-    # e.g. a CommandError because echo could not be found, would lead to an
-    # early test-exit and not proceed to the assign-statement.
-    assert echo.returncode in (0, -15)
+    # results in a -15 or a 1 return code. Any other exception than
+    # StopIteration, e.g. a CommandError because echo could not be found, would
+    # lead to an early test-exit and not proceed to the assign-statement.
+    assert echo.returncode in (0, 1, -15)


### PR DESCRIPTION
Fixes #32 

This PR extends the return code check in `test_returncode_available_from_generator_with_exception` to include the return code from termination on a Windows system.
