### PR TITLE
Fix handling of multiple encoding errors in `decode_bytes` input chunks.

### DIFF
--- a/datasalad/itertools/decode_bytes.py
+++ b/datasalad/itertools/decode_bytes.py
@@ -102,7 +102,7 @@ def decode_bytes(
             raise exc
         return (
             position + exc.end,
-            joined_data[: position + exc.start].decode(encoding)
+            joined_data[position : position + exc.start].decode(encoding)
             + joined_data[position + exc.start : position + exc.end].decode(
                 encoding, errors='backslashreplace'
             ),

--- a/datasalad/itertools/tests/test_decode_bytes.py
+++ b/datasalad/itertools/tests/test_decode_bytes.py
@@ -35,3 +35,8 @@ def test_no_empty_strings():
     # check that empty strings are not yielded
     r = tuple(decode_bytes([b'\xc3', b'\xb6']))
     assert r == ('ö',)
+
+
+def test_multiple_errors():
+    r = ''.join(decode_bytes([b'08 War \xaf No \xaf More \xaf Trouble.shn.mp3']))
+    assert r == '08 War \\xaf No \\xaf More \\xaf Trouble.shn.mp3'


### PR DESCRIPTION
This PR fixes a bug that was detected by @mih and addressed [here](https://github.com/datalad/datalad-next/pull/742). Due to this bug, multiple encoding errors in a single input chunk of `decode_bytes` lead to unexpected decoding exceptions.

The PR adds a regression test to ensure that multiple encoding errors in a single input chunk are handled properly.
