### PR TITLE
chore: consolidate changelog "looks" in template

### DIFF
--- a/.changelog.md.j2
+++ b/.changelog.md.j2
@@ -4,8 +4,17 @@
 
 {% for change_key, changes in entry.changes.items() %}
 
+{% set change_key_map = {
+  'BREAKING CHANGE': '🪓 Breaking changes',
+  'doc': '📝 Documentation',
+  'feat': '💫 New features',
+  'fix': '🐛 Bug Fixes',
+  'test': '🛡 Tests',
+  'rf': '🏠 Refactorings',
+  'perf': '🚀 Performance improvements',
+} %}
 {% if change_key %}
-## {{ change_key }}
+## {{ change_key_map.get(change_key, change_key) }}
 {% endif %}
 {% set scopemap = {
   'changelog': 'Changelog',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,12 +231,3 @@ schema_pattern = "(?s)(ci|doc|feat|fix|perf|rf|style|test|chore|revert|bump)(\\(
 "^BREAKING" = "MAJOR"
 "^feat" = "MINOR"
 "^fix" = "PATCH"
-
-[tool.commitizen.customize.change_type_map]
-"BREAKING CHANGE" = "Breaking changes"
-doc = "Documentation"
-feat = "New features"
-fix = "Bug Fixes"
-test = "Tests"
-rf = "Refactorings"
-perf = "Performance improvements"


### PR DESCRIPTION
Before the mapping from change type keys to verbose names was in pyproject.toml, but that file is quite full already. We need not have it be concerned with the looks of changelog generation, when most of that is in the template already.