### PR TITLE
chore: tune documentation setup

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -31,3 +31,5 @@ python:
    install:
    - method: pip
      path: .
+     extra_requirements:
+       - docs

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= --fail-on-warning
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -1,0 +1,9 @@
+{{ fullname }}
+{{ underline }}
+
+.. currentmodule:: {{ module }}
+.. autoclass:: {{ fullname }}
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __eq__

--- a/docs/_templates/autosummary/module.rst
+++ b/docs/_templates/autosummary/module.rst
@@ -1,0 +1,4 @@
+{{ fullname }}
+{{ underline }}
+
+.. automodule:: {{ fullname }}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,25 +6,32 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
+import datasalad
+
 project = 'datasalad'
 copyright = '2024, DataLad team'
 author = 'DataLad team'
-release = 'v0.0.1-rc2'
+release = datasalad.__version__
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
     'sphinx.ext.autosummary',
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autodoc.typehints',
+    'sphinx.ext.viewcode',
 ]
 
 templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+primary_domain = 'py'
+autoclass_content = "both"
 
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 html_static_path = ['_static']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,12 @@ Issues = "https://github.com/datalad/datasalad/issues"
 Source = "https://github.com/datalad/datasalad"
 Changelog = "https://github.com/datalad/datasalad/blob/main/CHANGELOG.md"
 
+[project.optional-dependencies]
+docs = [
+  "sphinx",
+  "sphinx_rtd_theme",
+]
+
 [tool.hatch.version]
 source = "vcs"
 
@@ -107,6 +113,7 @@ check = [
 description = "build Sphinx-based docs"
 extra-dependencies = [
   "sphinx",
+  "sphinx_rtd_theme",
 ]
 [tool.hatch.envs.docs.scripts]
 build = [


### PR DESCRIPTION
Use a leaner automodule documentation. Go with a select list of to-be-documented module content, rather than everything. This enables using content overview tables without running into duplication issues with Sphinx.

Use the RTD theme and polish the presentation of information a bit.