### PR TITLE
feat: inherit `CommandError` (also) from `subprocess.CalledProcessError`

### DIFF
--- a/datasalad/runners/exception.py
+++ b/datasalad/runners/exception.py
@@ -8,10 +8,11 @@ if TYPE_CHECKING:
     import os
 
 import signal
+import subprocess
 import sys
 
 
-class CommandError(RuntimeError):
+class CommandError(subprocess.CalledProcessError, RuntimeError):
     """Raised when a subprocess execution fails (non-zero exit)
 
     Key class attributes are aligned with the ``CalledProcessError`` exception
@@ -49,11 +50,14 @@ class CommandError(RuntimeError):
         cwd: str | os.PathLike | None = None,
     ) -> None:
         RuntimeError.__init__(self, msg)
-        self.cmd = cmd
+        subprocess.CalledProcessError.__init__(
+            self,
+            returncode=returncode,
+            cmd=cmd,
+            output=stdout,
+            stderr=stderr,
+        )
         self.msg = msg
-        self.returncode = returncode
-        self.stdout = stdout
-        self.stderr = stderr
         self.cwd = cwd
 
     def __str__(self) -> str:

--- a/datasalad/runners/tests/test_exception.py
+++ b/datasalad/runners/tests/test_exception.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 import sys
 
 import pytest
@@ -12,6 +13,10 @@ def test_CommandError_minial():
         # we need a command
         CommandError()
 
+def test_CommandError_multiple_inheritence():
+    ce = CommandError('dummy')
+    assert isinstance(ce, RuntimeError)
+    assert isinstance(ce, subprocess.CalledProcessError)
 
 def test_CommandError_str_repr() -> None:
     unicode_out = 'ΔЙקم๗あösdohabcdefdf0j23d2däüß§!אؠॵΔЙקم๗あöäüß§!אؠॵℱ⏰︻𐂃𐃍'


### PR DESCRIPTION
In the DataLad world `CommandError` was traditionally a `RuntimeError`. Whether or not that makes sense in the general case, one can have different opinions about.

The rest of the world is using `subprocess.CalledProcessError`. This exception type is very similar to `CommandError` in the properties that it can capture. It is only missing the CWD info, and the context message that comes with `RuntimeError` (see class docs).

This change connects the two worlds, by inheriting from both `RuntimeError` and `CalledProcessError`, and using the properties of both, where possible.

The behavior of `CommandError` remains unchanged, but it will now also work with code that expects a `subprocess` exception.