### PR TITLE
ci: avoid command duplication in CI and use set -x to visualize what is ran

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -20,5 +20,4 @@ jobs:
         run: python -m pip install commitizen
       - name: Run commit message checks
         run: |
-          echo cz check --rev-range ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
-          cz check --rev-range ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
+          set -x; cz check --rev-range ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Just treating my duplication allergy

TODO:
- [x] check that it works as desired (note: set -x better be on the same line to be more "descriptive" instead of just `set -x`)
![image](https://github.com/user-attachments/assets/3a822597-2791-4a45-b5a4-33395f9549ae)
