### PR TITLE
rf: use PY3.9 as minimum version

### DIFF
--- a/datasalad/gitpathspec/pathspec.py
+++ b/datasalad/gitpathspec/pathspec.py
@@ -6,7 +6,10 @@ from __future__ import annotations
 import posixpath
 from dataclasses import dataclass
 from fnmatch import fnmatch
-from typing import Generator
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 @dataclass(frozen=True)

--- a/datasalad/iterable_subprocess/iterable_subprocess.py
+++ b/datasalad/iterable_subprocess/iterable_subprocess.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 from collections import deque
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
 from contextlib import contextmanager
 from subprocess import PIPE, Popen
 from threading import Thread
 from typing import (
     TYPE_CHECKING,
-    Iterable,
 )
 
 if TYPE_CHECKING:
@@ -180,21 +179,25 @@ def iterable_subprocess(
     exception_stderr = None
 
     try:
-        with Popen(  # nosec - all arguments are controlled by the caller
-            program,
-            stdin=PIPE,
-            stdout=PIPE,
-            stderr=PIPE,
-            cwd=cwd,
-            bufsize=bufsize,
-        ) as proc, thread(
-            keep_only_most_recent,
-            proc.stderr,
-            stderr_deque,
-        ) as (start_t_stderr, join_t_stderr), thread(
-            input_to,
-            proc.stdin,
-        ) as (start_t_stdin, join_t_stdin):
+        with (
+            Popen(  # nosec - all arguments are controlled by the caller
+                program,
+                stdin=PIPE,
+                stdout=PIPE,
+                stderr=PIPE,
+                cwd=cwd,
+                bufsize=bufsize,
+            ) as proc,
+            thread(
+                keep_only_most_recent,
+                proc.stderr,
+                stderr_deque,
+            ) as (start_t_stderr, join_t_stderr),
+            thread(
+                input_to,
+                proc.stdin,
+            ) as (start_t_stdin, join_t_stdin),
+        ):
             try:
                 start_t_stderr()
                 start_t_stdin()

--- a/datasalad/itertools/align_pattern.py
+++ b/datasalad/itertools/align_pattern.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import re
 from typing import (
-    Generator,
-    Iterable,
+    TYPE_CHECKING,
     TypeVar,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable
 
 S = TypeVar('S', str, bytes, bytearray)
 

--- a/datasalad/itertools/decode_bytes.py
+++ b/datasalad/itertools/decode_bytes.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from typing import (
-    Generator,
-    Iterable,
-)
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable
 
 __all__ = ['decode_bytes']
 

--- a/datasalad/itertools/itemize.py
+++ b/datasalad/itertools/itemize.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from typing import (
-    Generator,
-    Iterable,
+    TYPE_CHECKING,
     TypeVar,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable
 
 __all__ = ['itemize']
 

--- a/datasalad/itertools/load_json.py
+++ b/datasalad/itertools/load_json.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import json
 from typing import (
+    TYPE_CHECKING,
     Any,
-    Generator,
-    Iterable,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable
 
 __all__ = ['load_json', 'load_json_with_flag']
 

--- a/datasalad/itertools/reroute.py
+++ b/datasalad/itertools/reroute.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
-    Generator,
-    Iterable,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable
 
 __all__ = ['StoreOnly', 'route_in', 'route_out']
 

--- a/datasalad/runners/iter_subproc.py
+++ b/datasalad/runners/iter_subproc.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import (
     TYPE_CHECKING,
-    Iterable,
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from pathlib import Path
 
 from datasalad import iterable_subprocess

--- a/datasalad/settings/defaults.py
+++ b/datasalad/settings/defaults.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import logging
 from typing import (
     TYPE_CHECKING,
-    Hashable,
 )
 
 from datasalad.settings.source import InMemory
 
 if TYPE_CHECKING:
+    from collections.abc import Hashable
+
     from datasalad.settings.setting import Setting
 
 lgr = logging.getLogger('datasalad.settings')

--- a/datasalad/settings/env.py
+++ b/datasalad/settings/env.py
@@ -9,14 +9,13 @@ from os import (
 )
 from typing import (
     TYPE_CHECKING,
-    Hashable,
 )
 
 from datasalad.settings.setting import Setting
 from datasalad.settings.source import WritableSource
 
 if TYPE_CHECKING:
-    from collections.abc import Collection
+    from collections.abc import Collection, Hashable
 
 lgr = logging.getLogger('datasalad.settings')
 

--- a/datasalad/settings/settings.py
+++ b/datasalad/settings/settings.py
@@ -6,12 +6,13 @@ from types import MappingProxyType
 from typing import (
     TYPE_CHECKING,
     Any,
-    Hashable,
 )
 
 from datasalad.settings.setting import Setting
 
 if TYPE_CHECKING:
+    from collections.abc import Hashable
+
     from datasalad.settings import Source
 
 

--- a/datasalad/settings/source.py
+++ b/datasalad/settings/source.py
@@ -7,14 +7,12 @@ from abc import (
 from typing import (
     TYPE_CHECKING,
     Any,
-    Generator,
-    Hashable,
 )
 
 from datasalad.settings.setting import Setting
 
 if TYPE_CHECKING:
-    from collections.abc import Collection
+    from collections.abc import Collection, Generator, Hashable
 
 
 class Source(ABC):

--- a/datasalad/settings/tests/test_env.py
+++ b/datasalad/settings/tests/test_env.py
@@ -1,10 +1,10 @@
+from collections.abc import Hashable
 from os import (
     environ,
 )
 from os import (
     name as os_name,
 )
-from typing import Hashable
 from unittest.mock import patch
 
 import pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "datasalad"
 dynamic = ["version"]
 description = 'utilities for working with data in the vicinity of Git and git-annex'
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = "MIT"
 keywords = [
   "datalad",
@@ -37,11 +37,11 @@ classifiers = [
   "Topic :: Software Development :: Version Control :: Git",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
@@ -98,7 +98,7 @@ extra-dependencies = [
 ]
 [tool.hatch.envs.types.scripts]
 check = [
-  "mypy --install-types --non-interactive --python-version 3.8 --pretty --show-error-context {args:datasalad}",
+  "mypy --install-types --non-interactive --python-version 3.9 --pretty --show-error-context {args:datasalad}",
 ]
 
 [tool.hatch.envs.docs]
@@ -181,7 +181,7 @@ exclude = [
 ]
 line-length = 88
 indent-width = 4
-target-version = "py38"
+target-version = "py39"
 [tool.ruff.format]
 # Prefer single quotes over double quotes.
 quote-style = "single"


### PR DESCRIPTION
Python 3.8 went EOL in Oct 2024. Discontinuing its support is not considered "breakage" for semantic versioning.

PY3.9 is now the target for formatting and type-checking.